### PR TITLE
Fix for more recent casbin versions and connection send fix

### DIFF
--- a/postgresql_watcher/watcher.py
+++ b/postgresql_watcher/watcher.py
@@ -31,7 +31,7 @@ def casbin_subscription(
             while conn.notifies:
                 notify = conn.notifies.pop(0)
                 print(f"Notify: {notify.payload}")
-                process_conn.put(notify.payload)
+                process_conn.send(notify.payload)
 
 
 class PostgresqlWatcher(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-casbin==0.8.4
+casbin>=0.8.4
 psycopg2-binary==2.8.6


### PR DESCRIPTION
- Allow the watcher to be used with casbin versions more recent than 0.8.4.
- Replaced call to process_con.put() with process_conn.send().  Trying to call .put() throws the error: AttributeError: 'Connection' object has no attribute 'put'
 (at least on MacOS)