### PR TITLE
fix: made should_reload into a blocking call

### DIFF
--- a/postgresql_watcher/watcher.py
+++ b/postgresql_watcher/watcher.py
@@ -87,7 +87,6 @@ class PostgresqlWatcher(object):
         )
         if start_process:
             p.start()
-        self.should_reload()
         return p
 
     def set_update_callback(self, fn_name: Callable):
@@ -113,7 +112,7 @@ class PostgresqlWatcher(object):
 
     def should_reload(self):
         try:
-            if self.parent_conn.poll():
+            if self.parent_conn.poll(None):
                 message = self.parent_conn.recv()
                 print(f"message:{message}")
                 return True

--- a/tests/test_postgresql_watcher.py
+++ b/tests/test_postgresql_watcher.py
@@ -39,9 +39,6 @@ class TestConfig(unittest.TestCase):
     def test_update_pg_watcher(self):
         assert pg_watcher.update() is True
 
-    def test_not_reload(self):
-        assert not pg_watcher.should_reload()
-
     def test_default_update_callback(self):
         assert pg_watcher.update_callback() is None
 


### PR DESCRIPTION
I have watcher code that looks something like this:

        adapter = casbin_sqlalchemy_adapter.Adapter(db_url)
        self._e = casbin.Enforcer(Config.casbin_conf_file, adapter)
        parsed_url = urllib.parse.urlparse(db_url)

        if db_adapter is True:
            self._watcher = PostgresqlWatcher(
                host=parsed_url.hostname, user=parsed_url.username, password=parsed_url.password,
                port=parsed_url.port, dbname=parsed_url.path.lstrip('/')
            )
            self._watcher.set_update_callback(self._e.load_policy)
            self._e.set_watcher(self._watcher)

            update_thread = threading.Thread(target=self.watcher_update, daemon=True)
            update_thread.start()

    def watcher_update(self):
        while True:
            # should_reload() calls poll() to wait for data - returns True if there's been an update
            if self._watcher.should_reload():
                self._watcher.update_callback()


However, with the current watcher implementation the watcher_update() thread will peg CPU as the poll() call in should_reload() is non-blocking.  I've changed this to a blocking call as well as removing the should_reload() call in create_subscriber_process(), which at the moment doesn't really do anything but would block the main thread if turned into a blocking call.

Unless I'm misunderstanding something, this is the only way I can get the watcher to work properly :).
           